### PR TITLE
Docker image fails to build [FIX]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 from alpine:latest
-RUN apk add --no-cache python3-dev \
+RUN apk add --no-cache py3-pip \
     && pip3 install --upgrade pip
 
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,1 @@
-aniso8601==7.0.0
-Click==7.0
 Flask==1.1.1
-Flask-RESTful==0.3.7
-itsdangerous==1.1.0
-Jinja2==2.10.1
-MarkupSafe==1.1.1
-pytz==2019.2
-six==1.12.0
-Werkzeug==0.15.5


### PR DESCRIPTION
The package python3-dev does not install pip3 so the following msg appears when attempting to build the docker file: **/bin/sh: pip3: not found**

Also the requirements.txt contains libs that already gets installed so when reattempting to install them again via "pip3 install", an error occurs and the docker file fails to build.

I've changed the requirements.txt and the dockerfile to fix the issues. The changes are tested on both Windows and Mac and they are working fine.

Thank you.